### PR TITLE
Removed obsolete reference in "browser support" to Opera not supporting radial gradients

### DIFF
--- a/index.html
+++ b/index.html
@@ -327,7 +327,7 @@ background-size: 50px;" title="Horizontal stripes"></li>
 	
 	<h2 id="browser-support">Browser support</h2>
 	<p>The patterns themselves should work on <strong>Firefox 3.6+</strong>, <strong>Chrome</strong>, <strong>Safari 5.1</strong>, <strong>Opera 11.10+</strong> and <strong>IE10+</strong>. 
-	However, implementation limitations might cause some of them to not be displayed correctly even on those browsers (for example at the time of writing, Opera doesn’t support radial gradients and Gecko is quite buggy with them).</p>
+	However, implementation limitations might cause some of them to not be displayed correctly even on those browsers (for example at the time of writing, Gecko is quite buggy with radial gradients).</p>
 	<p>Also, this gallery won’t work in Firefox 3.6 and IE10, even though they support gradients, due to a JavaScript limitation.</p>
 	
 	<h2 id="new-submissions">Submission guidelines</h2>


### PR DESCRIPTION
Fingers crossed for my first ever pull request to someone else's repo.....
